### PR TITLE
Mirror of chef automate#4392

### DIFF
--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -1,132 +1,134 @@
-<div class="content-container" [ngStyle]="height" [ngClass]="loading(loadedStatus$ | async) ? 'lock-scrolling' : ''">
-  <div class="container">
+<div class="auto_height">
+  <div class="content-container" [ngClass]="loading(loadedStatus$ | async) ? 'lock-scrolling' : ''">
+    <div class="container">
 
-    <div class="sticky-notifications">
-      <div class="sticky-inner">
-        <app-notification
-          *ngIf="notificationVisible"
-          [type]="'error'"
-          [timeout]="8"
-          (dismissed)="hideNotification()">
-          Failed to retrieve data.
-        </app-notification>
-      </div>
-    </div>
-    <main>
-      <div class="node-list-container">
-        <chef-page-header>
-          <chef-heading>Client Runs</chef-heading>
-          <chef-subheading>Nodes connected to Chef Automate by way of Chef Infra Client.</chef-subheading>
-
-          <app-search-bar
-            [numberOfFilters]="numberOfSearchBarFilters$ | async"
-            [categories]="categoryTypes"
-            [dynamicSuggestions]="nodeSuggestions$ | async"
-            (suggestValues)="onSuggestValues($event)"
-            (itemSelected)="onFilterAdded($event)"
-            (filtersButtonClick)="toggleFilters()">
-          </app-search-bar>
-          <div class="copy-dropdown">
-            <chef-button class="dropdown-toggle" secondary (click)="toggleShareDropdown()">
-              <chef-icon>share</chef-icon>
-            </chef-button>
-            <chef-dropdown class="dropdown" [visible]="shareDropdownVisible">
-              <chef-click-outside (clickOutside)="hideShareDropdown()" omit="dropdown-toggle">
-                <p>Copy this private URL to share:</p>
-                <div class="copy-input">
-                  <input type="text" aria-label="URL" [value]="shareUrl" readonly />
-                  <chef-clipboard [value]="shareUrl"></chef-clipboard>
-                </div>
-              </chef-click-outside>
-            </chef-dropdown>
-          </div>
-          <div class="download-nodes">
-            <chef-button class="dropdown-toggle" secondary (click)="toggleDownloadDropdown()">
-              <chef-icon>cloud_download</chef-icon>
-            </chef-button>
-            <chef-dropdown class="dropdown" [visible]="downloadOptsVisible">
-              <chef-click-outside (clickOutside)="hideDownloadDropdown()" omit="dropdown-toggle">
-                <chef-button tertiary (click)="onDownloadOptPressed('json')">Download JSON</chef-button>
-                <chef-button tertiary (click)="onDownloadOptPressed('csv')">Download CSV</chef-button>
-              </chef-click-outside>
-            </chef-dropdown>
-          </div>
-
-          <app-search-bar-filter-bar *ngIf="filtersVisible"
-            [filters]="searchBarFilters$ | async"
-            (filtersCleared)="onFiltersClear($event)"
-            (filterRemoved)="onFilterRemoved($event)">
-          </app-search-bar-filter-bar>
-        </chef-page-header>
-        <div class="page-body">
-          <ng-container>
-            <div class="stats-box">
-              <app-converge-radial-graph [count]="nodeCounts$ | async"></app-converge-radial-graph>
-            </div>
-          </ng-container>
-          <!-- Converge Status elements -->
-          <div class="node-rollups">
-            <app-node-rollup
-              class="total"
-              [name]="'total'"
-              [count]="totalNodeCount$ | async"
-              [active]="isTotalStatusSelected$ | async"
-              (activated)="statusFilter('total')">
-            </app-node-rollup>
-            <app-node-rollup
-              class="failure"
-              [name]="'failure'"
-              [count]="failNodeCount$ | async"
-              [active]="isFailureStatusSelected$ | async"
-              (activated)="statusFilter('failure')">
-            </app-node-rollup>
-            <app-node-rollup
-              class="success"
-              [name]="'success'"
-              [count]="successNodeCount$ | async"
-              [active]="isSuccessStatusSelected$ | async"
-              (activated)="statusFilter('success')">
-            </app-node-rollup>
-            <app-node-rollup
-              class="missing"
-              [name]="'missing'"
-              [count]="missingNodeCount$ | async"
-              [active]="isMissingStatusSelected$ | async"
-              (activated)="statusFilter('missing')">
-            </app-node-rollup>
-          </div>
-          <app-client-runs-table
-            [totalNodes]= "totalNumberOfNodesWithStatusFilter$ | async"
-            [nodes]="nodes$ | async"
-            [selectedFieldDirection]="fieldDirection$ | async"
-            [selectedSortField]="sortField$ | async"
-            [currentPage]="currentPage$ | async"
-            [pageSize]="pageSize"
-            [columns]="columns$ | async"
-            [defaultFieldDirection]="defaultFieldDirection"
-            [loading]="loading(loadedStatus$ | async)"
-            [canDeleteNodes]="authorizedChecker.isAuthorized$ | async"
-            (deleteNodes)="onDeleteNodes($event)"
-            (updateSort)="onUpdateSort($event)"
-            (pageChange)="onPageChange($event)"
-            (updateColumns)="onUpdateColumns($event)">
-          </app-client-runs-table>
+      <div class="sticky-notifications">
+        <div class="sticky-inner">
+          <app-notification
+            *ngIf="notificationVisible"
+            [type]="'error'"
+            [timeout]="8"
+            (dismissed)="hideNotification()">
+            Failed to retrieve data.
+          </app-notification>
         </div>
       </div>
+      <main>
+        <div class="node-list-container">
+          <chef-page-header>
+            <chef-heading>Client Runs</chef-heading>
+            <chef-subheading>Nodes connected to Chef Automate by way of Chef Infra Client.</chef-subheading>
 
-      <chef-modal
-        id="download-modal"
-        title="download-title"
-        [visible]="downloadStatusVisible"
-        (closeModal)="hideDownloadStatus()">
-        <ng-container *ngIf="downloadInProgress">
-          <h2 id="download-report" class="display4" slot="title">Downloading report...</h2>
-        </ng-container>
-        <ng-container *ngIf="downloadFailed">
-          <h2 id="download-failed" class="display4" slot="title">Download failed.</h2>
-        </ng-container>
-        <chef-loading-spinner *ngIf="downloadInProgress" size="50"></chef-loading-spinner>
-      </chef-modal>
-    </main>
+            <app-search-bar
+              [numberOfFilters]="numberOfSearchBarFilters$ | async"
+              [categories]="categoryTypes"
+              [dynamicSuggestions]="nodeSuggestions$ | async"
+              (suggestValues)="onSuggestValues($event)"
+              (itemSelected)="onFilterAdded($event)"
+              (filtersButtonClick)="toggleFilters()">
+            </app-search-bar>
+            <div class="copy-dropdown">
+              <chef-button class="dropdown-toggle" secondary (click)="toggleShareDropdown()">
+                <chef-icon>share</chef-icon>
+              </chef-button>
+              <chef-dropdown class="dropdown" [visible]="shareDropdownVisible">
+                <chef-click-outside (clickOutside)="hideShareDropdown()" omit="dropdown-toggle">
+                  <p>Copy this private URL to share:</p>
+                  <div class="copy-input">
+                    <input type="text" aria-label="URL" [value]="shareUrl" readonly />
+                    <chef-clipboard [value]="shareUrl"></chef-clipboard>
+                  </div>
+                </chef-click-outside>
+              </chef-dropdown>
+            </div>
+            <div class="download-nodes">
+              <chef-button class="dropdown-toggle" secondary (click)="toggleDownloadDropdown()">
+                <chef-icon>cloud_download</chef-icon>
+              </chef-button>
+              <chef-dropdown class="dropdown" [visible]="downloadOptsVisible">
+                <chef-click-outside (clickOutside)="hideDownloadDropdown()" omit="dropdown-toggle">
+                  <chef-button tertiary (click)="onDownloadOptPressed('json')">Download JSON</chef-button>
+                  <chef-button tertiary (click)="onDownloadOptPressed('csv')">Download CSV</chef-button>
+                </chef-click-outside>
+              </chef-dropdown>
+            </div>
+
+            <app-search-bar-filter-bar *ngIf="filtersVisible"
+              [filters]="searchBarFilters$ | async"
+              (filtersCleared)="onFiltersClear($event)"
+              (filterRemoved)="onFilterRemoved($event)">
+            </app-search-bar-filter-bar>
+          </chef-page-header>
+          <div class="page-body">
+            <ng-container>
+              <div class="stats-box">
+                <app-converge-radial-graph [count]="nodeCounts$ | async"></app-converge-radial-graph>
+              </div>
+            </ng-container>
+            <!-- Converge Status elements -->
+            <div class="node-rollups">
+              <app-node-rollup
+                class="total"
+                [name]="'total'"
+                [count]="totalNodeCount$ | async"
+                [active]="isTotalStatusSelected$ | async"
+                (activated)="statusFilter('total')">
+              </app-node-rollup>
+              <app-node-rollup
+                class="failure"
+                [name]="'failure'"
+                [count]="failNodeCount$ | async"
+                [active]="isFailureStatusSelected$ | async"
+                (activated)="statusFilter('failure')">
+              </app-node-rollup>
+              <app-node-rollup
+                class="success"
+                [name]="'success'"
+                [count]="successNodeCount$ | async"
+                [active]="isSuccessStatusSelected$ | async"
+                (activated)="statusFilter('success')">
+              </app-node-rollup>
+              <app-node-rollup
+                class="missing"
+                [name]="'missing'"
+                [count]="missingNodeCount$ | async"
+                [active]="isMissingStatusSelected$ | async"
+                (activated)="statusFilter('missing')">
+              </app-node-rollup>
+            </div>
+            <app-client-runs-table
+              [totalNodes]= "totalNumberOfNodesWithStatusFilter$ | async"
+              [nodes]="nodes$ | async"
+              [selectedFieldDirection]="fieldDirection$ | async"
+              [selectedSortField]="sortField$ | async"
+              [currentPage]="currentPage$ | async"
+              [pageSize]="pageSize"
+              [columns]="columns$ | async"
+              [defaultFieldDirection]="defaultFieldDirection"
+              [loading]="loading(loadedStatus$ | async)"
+              [canDeleteNodes]="authorizedChecker.isAuthorized$ | async"
+              (deleteNodes)="onDeleteNodes($event)"
+              (updateSort)="onUpdateSort($event)"
+              (pageChange)="onPageChange($event)"
+              (updateColumns)="onUpdateColumns($event)">
+            </app-client-runs-table>
+          </div>
+        </div>
+
+        <chef-modal
+          id="download-modal"
+          title="download-title"
+          [visible]="downloadStatusVisible"
+          (closeModal)="hideDownloadStatus()">
+          <ng-container *ngIf="downloadInProgress">
+            <h2 id="download-report" class="display4" slot="title">Downloading report...</h2>
+          </ng-container>
+          <ng-container *ngIf="downloadFailed">
+            <h2 id="download-failed" class="display4" slot="title">Download failed.</h2>
+          </ng-container>
+          <chef-loading-spinner *ngIf="downloadInProgress" size="50"></chef-loading-spinner>
+        </chef-modal>
+      </main>
+    </div>
   </div>
 </div>

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.html
@@ -1,4 +1,4 @@
-<div class="content-container" [ngClass]="loading(loadedStatus$ | async) ? 'lock-scrolling' : ''">
+<div class="content-container" [ngStyle]="height" [ngClass]="loading(loadedStatus$ | async) ? 'lock-scrolling' : ''">
   <div class="container">
 
     <div class="sticky-notifications">

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.scss
@@ -125,3 +125,7 @@ app-client-runs-search-filters {
 .lock-scrolling {
   overflow: hidden;
 }
+
+.auto_height {
+  min-height: calc(100vh - 49px);
+}

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -242,8 +242,6 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   downloadFailed = false;
   downloadStatusVisible = false;
 
-  scrolling = false;
-
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -384,9 +382,9 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   }
 
   // prevent scrolling on tabs change
-  get height() {
+  get height(): { [cssClass: string]: string; }  {
     return {
-      'min-height': this.scrolling ? 'calc(100vh - 50px)' : 'calc(100vh - 49px)'
+      'min-height': 'calc(100vh - 49px)'
     };
   }
 

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -242,6 +242,8 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
   downloadFailed = false;
   downloadStatusVisible = false;
 
+  scrolling = false;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -379,6 +381,13 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
         verb: 'post'
       }
     ], []);
+  }
+
+  // prevent scrolling on tabs change
+  get height() {
+    return {
+      'min-height': this.scrolling ? 'calc(100vh - 50px)' : 'calc(100vh - 49px)'
+    };
   }
 
   hideNotification() {

--- a/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
+++ b/components/automate-ui/src/app/pages/client-runs/client-runs.component.ts
@@ -381,13 +381,6 @@ export class ClientRunsComponent implements OnInit, OnDestroy {
     ], []);
   }
 
-  // prevent scrolling on tabs change
-  get height(): { [cssClass: string]: string; }  {
-    return {
-      'min-height': 'calc(100vh - 49px)'
-    };
-  }
-
   hideNotification() {
     this.notificationVisible = false;
   }


### PR DESCRIPTION
Mirror of chef automate#4392
Signed-off-by: Vinay Sharma <vsharma<at>chef.io>

### :nut_and_bolt: Description: What code changed, and why?
As a user, when i'm on the client runs page I want to be able to smoothly filter my client runs while maintaining my scroll depth on the page.
I have added some changes to preventing jump to top of screen
<!-- /!\ Please ensure that you are NOT disclosing any customer information without their consent /!\ -->

### :chains: Related Resources
https://github.com/chef/automate/issues/3759

### :+1: Definition of Done
I have added one function which can find existing height of the component and again set the existing height after changing the tab.
### :athletic_shoe: How to Build and Test the Change
```
STEP 1
inside the hab studio

[default:/src:0]# build components/automate-ui-devproxy/
[default:/src:0]# start_automate_ui_background
[default:/src:0]# start_all_services

STEP 2
open new window
go to automate UI path

$ cd components/automate-ui
and run the command 

npm run serve:hab

navigate to `https://a2-dev.test/infrastructure/client-runs`
add some sample data and then test the changes using tab change
```
### :white_check_mark: Checklist

- [ ] I have read the [CONTRIBUTING document](https://github.com/chef/automate/blob/master/CONTRIBUTING.md).
- [ ] Tests added/updated?
- [ ] Docs added/updated?
- [ ] All commits have been signed-off for the [Developer Certification of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### :camera: Screenshots, if applicable

![client_runs](https://user-images.githubusercontent.com/12297653/95195647-7ae25500-07f4-11eb-9a4b-c7e44c962fcb.gif)

